### PR TITLE
Add common direnv files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,10 @@ ENV/
 env.bak/
 venv.bak/
 
+# Direnv
+.envrc
+.direnv
+
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
If people use direnv to manage python virtual environments, there will be a .envrc file in the project root that specifies the desired python version, and direnv will create a .direnv directory in the project root to contain the venv. These should be excluded from commits.